### PR TITLE
Refactor URL/Routes to match Drupal

### DIFF
--- a/app/components/auth/loginCall.js
+++ b/app/components/auth/loginCall.js
@@ -39,11 +39,8 @@ export const loginCall = (username, password) => {
         });
       })
       .then(response => {
-        // store id
         const id = response.data.meta.links.me.meta.id;
-        data.id = id;
-        setCookie('id', id);
-        // Obtain the user's username using the user's id
+        // Obtain the user's username/drupal_internal__uid using the user's id
         return axios.get(`${API_URL}/jsonapi/user/user/${id}`, {
           headers: {
             Authorization: `Bearer ${data.token}`,
@@ -51,6 +48,10 @@ export const loginCall = (username, password) => {
         });
       })
       .then(response => {
+        // store id
+        const drupalId = response.data.data.attributes.drupal_internal__uid;
+        data.id = drupalId;
+        setCookie('id', drupalId);
         // store username
         const name = decodeURI(response.data.data.attributes.name);
         data.username = name;

--- a/app/components/molecules/AccountNavigation/index.js
+++ b/app/components/molecules/AccountNavigation/index.js
@@ -137,7 +137,7 @@ const AccountNavigation = ({t}) => {
             >
               <ul>
                 <li>
-                  <Link href="/signup">
+                  <Link href="/user/register">
                     <a>{t('sign-up')}</a>
                   </Link>
                 </li>
@@ -152,7 +152,7 @@ const AccountNavigation = ({t}) => {
           <DesktopWrapper>
             <ul>
               <li>
-                <Link href="/signup">
+                <Link href="/user/register">
                   <a>{t('sign-up')}</a>
                 </Link>
               </li>

--- a/app/components/molecules/AccountNavigation/index.js
+++ b/app/components/molecules/AccountNavigation/index.js
@@ -142,7 +142,7 @@ const AccountNavigation = ({t}) => {
                   </Link>
                 </li>
                 <li>
-                  <Link href="/login">
+                  <Link href="/user/login">
                     <a>{t('log-in')}</a>
                   </Link>
                 </li>
@@ -157,7 +157,7 @@ const AccountNavigation = ({t}) => {
                 </Link>
               </li>
               <li>
-                <Link href="/login">
+                <Link href="/user/login">
                   <a>{t('log-in')}</a>
                 </Link>
               </li>

--- a/app/components/molecules/AccountNavigation/index.js
+++ b/app/components/molecules/AccountNavigation/index.js
@@ -244,45 +244,33 @@ const AccountNavigation = ({t}) => {
             <ul>
               <DropdownHeader>
                 {t('signed-in-as')}
-                <Link href={`/user?id=${user.id}`}>
+                <Link href={`/user/${user.id}/stream`}>
                   <a>{user.username}</a>
                 </Link>
               </DropdownHeader>
               <ListDivider />
               <li>
-                <Link href={`/user?id=${user.id}`}>
+                <Link href={`/user/${user.id}/stream`}>
                   <a>{t('my-stream')}</a>
                 </Link>
               </li>
               <li>
-                <Link
-                  href={`/userevents?id=${user.id}`}
-                  as={`/user?id=${user.id}/events`}
-                >
+                <Link href={`/user/${user.id}/events`}>
                   <a>{t('my-events')}</a>
                 </Link>
               </li>
               <li>
-                <Link
-                  href={`/usertopics?id=${user.id}`}
-                  as={`/user?id=${user.id}/topics`}
-                >
+                <Link href={`/user/${user.id}/topics`}>
                   <a>{t('my-topics')}</a>
                 </Link>
               </li>
               <li>
-                <Link
-                  href={`/usergroups?id=${user.id}`}
-                  as={`/user?id=${user.id}/groups`}
-                >
+                <Link href={`/user/${user.id}/groups`}>
                   <a>{t('my-groups')}</a>
                 </Link>
               </li>
               <li>
-                <Link
-                  href={`/userinformation?id=${user.id}`}
-                  as={`/user?id=${user.id}/information`}
-                >
+                <Link href={`/user/${user.id}/information`}>
                   <a>{t('my-information')}</a>
                 </Link>
               </li>

--- a/app/components/molecules/AccountNavigation/index.js
+++ b/app/components/molecules/AccountNavigation/index.js
@@ -287,7 +287,7 @@ const AccountNavigation = ({t}) => {
                 </Link>
               </li>
               <li>
-                <Link href="/editprofile">
+                <Link href={`/user/${user.id}/profile`}>
                   <a>{t('edit-profile')}</a>
                 </Link>
               </li>

--- a/app/components/molecules/ProfileNavigationBar/index.js
+++ b/app/components/molecules/ProfileNavigationBar/index.js
@@ -70,7 +70,7 @@ function ProfileNavigationBar(props) {
         onClick={() => props.setCurrentTab('stream')}
         active={props.currentTab === 'stream'}
       >
-        <Link href={`/user?id=${props.userId}`} scroll={false}>
+        <Link href={`/user/${props.userId}/stream`} scroll={false}>
           <a>Stream</a>
         </Link>
       </MenuItem>
@@ -78,11 +78,7 @@ function ProfileNavigationBar(props) {
         onClick={() => props.setCurrentTab('events')}
         active={props.currentTab === 'events'}
       >
-        <Link
-          href={`/userevents?id=${props.userId}`}
-          as={`/user?id=${props.userId}/events`}
-          scroll={false}
-        >
+        <Link href={`/user/${props.userId}/events`} scroll={false}>
           <a>Events</a>
         </Link>
       </MenuItem>
@@ -90,11 +86,7 @@ function ProfileNavigationBar(props) {
         onClick={() => props.setCurrentTab('topics')}
         active={props.currentTab === 'topics'}
       >
-        <Link
-          href={`/usertopics?id=${props.userId}`}
-          as={`/user?id=${props.userId}/topics`}
-          scroll={false}
-        >
+        <Link href={`/user/${props.userId}/topics`} scroll={false}>
           <a>Topics</a>
         </Link>
       </MenuItem>
@@ -102,11 +94,7 @@ function ProfileNavigationBar(props) {
         onClick={() => props.setCurrentTab('groups')}
         active={props.currentTab === 'groups'}
       >
-        <Link
-          href={`/usergroups?id=${props.userId}`}
-          as={`/user?id=${props.userId}/groups`}
-          scroll={false}
-        >
+        <Link href={`/user/${props.userId}/groups`} scroll={false}>
           <a>Groups</a>
         </Link>
       </MenuItem>
@@ -114,11 +102,7 @@ function ProfileNavigationBar(props) {
         onClick={() => props.setCurrentTab('information')}
         active={props.currentTab === 'information'}
       >
-        <Link
-          href={`/userinformation?id=${props.userId}`}
-          as={`/user?id=${props.userId}/information`}
-          scroll={false}
-        >
+        <Link href={`/user/${props.userId}/information`} scroll={false}>
           <a>Information</a>
         </Link>
       </MenuItem>

--- a/app/components/molecules/UserCard/index.js
+++ b/app/components/molecules/UserCard/index.js
@@ -9,6 +9,7 @@ import HorizontalLine from '../../atoms/HorizontalLine';
 import UserStats from '../UserStats';
 import TextButton from '../../atoms/TextButton';
 import Link from 'next/link';
+import {useUser} from '../../auth/userContext';
 
 const ProfileAvatar = styled(Avatar)`
   margin-top: -75px;
@@ -83,11 +84,12 @@ const StyledTextButton = styled(TextButton)`
 `;
 
 function UserCard(props) {
+  const user = useUser();
   // if the profile belongs to the logged in user render the editprofile button
   let profileButton;
-  if (props.loggedInUserId == props.profileId) {
+  if (user.id == props.id) {
     profileButton = (
-      <Link href="/editprofile">
+      <Link href={`/user/${user.id}/profile`}>
         <BaseButton radius="small" fontWeight="bold">
           Edit profile
         </BaseButton>

--- a/app/pages/_app.js
+++ b/app/pages/_app.js
@@ -23,7 +23,7 @@ class MyApp extends App {
         userData = {
           isLoggedIn: true,
           token: getCookie('token', ctx.req),
-          username: getCookie('username', ctx.req).replace('%20', ' '),
+          username: decodeURI(getCookie('username', ctx.req)),
           id: getCookie('id', ctx.req),
           avatar: getCookie('avatar', ctx.req),
         };

--- a/app/pages/_app.js
+++ b/app/pages/_app.js
@@ -23,7 +23,7 @@ class MyApp extends App {
         userData = {
           isLoggedIn: true,
           token: getCookie('token', ctx.req),
-          username: getCookie('username', ctx.req),
+          username: getCookie('username', ctx.req).replace('%20', ' '),
           id: getCookie('id', ctx.req),
           avatar: getCookie('avatar', ctx.req),
         };

--- a/app/pages/user/[id]/events.js
+++ b/app/pages/user/[id]/events.js
@@ -4,19 +4,20 @@ import axios from 'axios';
 import {useRouter} from 'next/router';
 import styled from 'styled-components';
 import React, {useState} from 'react';
-import Layout from '../components/Layout';
-import {API_URL} from '../utils/constants';
-import ProfileHero from '../components/atoms/ProfileHero';
-import UserCard from '../components/molecules/UserCard';
-import ProfileNavigationBar from '../components/molecules/ProfileNavigationBar';
-import ProfileInformation from '../components/organisms/ProfileInformation';
-import ProfileStream from '../components/organisms/ProfileStream';
-import ProfileEvents from '../components/organisms/ProfileEvents';
-import ProfileTopics from '../components/organisms/ProfileTopics';
-import ProfileGroups from '../components/organisms/ProfileGroups';
-import {deviceMinWidth, deviceMaxWidth} from '../utils/device';
-import HorizontalLine from '../components/atoms/HorizontalLine';
-import RecentActivity from '../components/organisms/RecentActivity';
+import Layout from '../../../components/Layout';
+import {API_URL} from '../../../utils/constants';
+import ProfileHero from '../../../components/atoms/ProfileHero';
+import UserCard from '../../../components/molecules/UserCard';
+import ProfileNavigationBar from '../../../components/molecules/ProfileNavigationBar';
+import ProfileInformation from '../../../components/organisms/ProfileInformation';
+import ProfileStream from '../../../components/organisms/ProfileStream';
+import ProfileEvents from '../../../components/organisms/ProfileEvents';
+import ProfileTopics from '../../../components/organisms/ProfileTopics';
+import ProfileGroups from '../../../components/organisms/ProfileGroups';
+import {deviceMinWidth, deviceMaxWidth} from '../../../utils/device';
+import HorizontalLine from '../../../components/atoms/HorizontalLine';
+import RecentActivity from '../../../components/organisms/RecentActivity';
+import {getCookie} from '../../../utils/cookie';
 
 const ProfileContentContainer = styled.div`
   display: flex;
@@ -68,10 +69,10 @@ const getAvailableTabs = () => ({
   information: ProfileInformation,
 });
 
-function UserTopics({name}) {
+function UserEvents({name}) {
   const router = useRouter();
 
-  const [currentTab, setCurrentTab] = useState('topics');
+  const [currentTab, setCurrentTab] = useState('events');
   const tabs = getAvailableTabs();
 
   if (typeof tabs[currentTab] === 'undefined') {
@@ -98,28 +99,31 @@ function UserTopics({name}) {
             setCurrentTab={setCurrentTab}
             userId={router.query.id}
           />
-          <ProfileTopics />
+          <ProfileEvents />
         </ProfileRightColumn>
       </ProfileContentContainer>
     </Layout>
   );
 }
 
-UserTopics.getInitialProps = ctx => {
+UserEvents.getInitialProps = async ctx => {
   // Get name of the user from the id passed in url
   return axios
-    .get(`${API_URL}/jsonapi/user/user/${ctx.query.id}`)
+    .get(
+      `${API_URL}/jsonapi/user/user?filter[drupal_internal__uid][value]=${ctx.query.id}`,
+      {
+        headers: {
+          Authorization: 'Bearer ' + getCookie('token', ctx.req),
+        },
+      },
+    )
     .then(response => {
-      const name = response.data.data.attributes.name;
+      const name = response.data.data[0].attributes.name;
       return {name};
     })
     .catch(err => {
-      throw new Error(`Error occured while fetching user: ${err}`);
+      throw new Error(`Error occured while fetching user`);
     });
 };
 
-UserTopics.propTypes = {
-  name: PropTypes.string,
-};
-
-export default UserTopics;
+export default UserEvents;

--- a/app/pages/user/[id]/groups.js
+++ b/app/pages/user/[id]/groups.js
@@ -4,19 +4,20 @@ import axios from 'axios';
 import {useRouter} from 'next/router';
 import styled from 'styled-components';
 import React, {useState} from 'react';
-import Layout from '../components/Layout';
-import {API_URL} from '../utils/constants';
-import ProfileHero from '../components/atoms/ProfileHero';
-import UserCard from '../components/molecules/UserCard';
-import ProfileNavigationBar from '../components/molecules/ProfileNavigationBar';
-import ProfileInformation from '../components/organisms/ProfileInformation';
-import ProfileStream from '../components/organisms/ProfileStream';
-import ProfileEvents from '../components/organisms/ProfileEvents';
-import ProfileTopics from '../components/organisms/ProfileTopics';
-import ProfileGroups from '../components/organisms/ProfileGroups';
-import {deviceMinWidth, deviceMaxWidth} from '../utils/device';
-import HorizontalLine from '../components/atoms/HorizontalLine';
-import RecentActivity from '../components/organisms/RecentActivity';
+import Layout from '../../../components/Layout';
+import {API_URL} from '../../../utils/constants';
+import ProfileHero from '../../../components/atoms/ProfileHero';
+import UserCard from '../../../components/molecules/UserCard';
+import ProfileNavigationBar from '../../../components/molecules/ProfileNavigationBar';
+import ProfileInformation from '../../../components/organisms/ProfileInformation';
+import ProfileStream from '../../../components/organisms/ProfileStream';
+import ProfileEvents from '../../../components/organisms/ProfileEvents';
+import ProfileTopics from '../../../components/organisms/ProfileTopics';
+import ProfileGroups from '../../../components/organisms/ProfileGroups';
+import {deviceMinWidth, deviceMaxWidth} from '../../../utils/device';
+import HorizontalLine from '../../../components/atoms/HorizontalLine';
+import RecentActivity from '../../../components/organisms/RecentActivity';
+import {getCookie} from '../../../utils/cookie';
 
 const ProfileContentContainer = styled.div`
   display: flex;
@@ -68,10 +69,10 @@ const getAvailableTabs = () => ({
   information: ProfileInformation,
 });
 
-function UserEvents({name}) {
+function UserGroups({name}) {
   const router = useRouter();
 
-  const [currentTab, setCurrentTab] = useState('events');
+  const [currentTab, setCurrentTab] = useState('groups');
   const tabs = getAvailableTabs();
 
   if (typeof tabs[currentTab] === 'undefined') {
@@ -98,28 +99,35 @@ function UserEvents({name}) {
             setCurrentTab={setCurrentTab}
             userId={router.query.id}
           />
-          <ProfileEvents />
+          <ProfileGroups />
         </ProfileRightColumn>
       </ProfileContentContainer>
     </Layout>
   );
 }
 
-UserEvents.getInitialProps = ctx => {
+UserGroups.getInitialProps = async ctx => {
   // Get name of the user from the id passed in url
   return axios
-    .get(`${API_URL}/jsonapi/user/user/${ctx.query.id}`)
+    .get(
+      `${API_URL}/jsonapi/user/user?filter[drupal_internal__uid][value]=${ctx.query.id}`,
+      {
+        headers: {
+          Authorization: 'Bearer ' + getCookie('token', ctx.req),
+        },
+      },
+    )
     .then(response => {
-      const name = response.data.data.attributes.name;
+      const name = response.data.data[0].attributes.name;
       return {name};
     })
     .catch(err => {
-      throw new Error(`Error occured while fetching user: ${err}`);
+      throw new Error(`Error occured while fetching user`);
     });
 };
 
-UserEvents.propTypes = {
+UserGroups.propTypes = {
   name: PropTypes.string,
 };
 
-export default UserEvents;
+export default UserGroups;

--- a/app/pages/user/[id]/information.js
+++ b/app/pages/user/[id]/information.js
@@ -4,19 +4,20 @@ import axios from 'axios';
 import {useRouter} from 'next/router';
 import styled from 'styled-components';
 import React, {useState} from 'react';
-import Layout from '../components/Layout';
-import {API_URL} from '../utils/constants';
-import ProfileHero from '../components/atoms/ProfileHero';
-import UserCard from '../components/molecules/UserCard';
-import ProfileNavigationBar from '../components/molecules/ProfileNavigationBar';
-import ProfileInformation from '../components/organisms/ProfileInformation';
-import ProfileStream from '../components/organisms/ProfileStream';
-import ProfileEvents from '../components/organisms/ProfileEvents';
-import ProfileTopics from '../components/organisms/ProfileTopics';
-import ProfileGroups from '../components/organisms/ProfileGroups';
-import {deviceMinWidth, deviceMaxWidth} from '../utils/device';
-import HorizontalLine from '../components/atoms/HorizontalLine';
-import RecentActivity from '../components/organisms/RecentActivity';
+import Layout from '../../../components/Layout';
+import {API_URL} from '../../../utils/constants';
+import ProfileHero from '../../../components/atoms/ProfileHero';
+import UserCard from '../../../components/molecules/UserCard';
+import ProfileNavigationBar from '../../../components/molecules/ProfileNavigationBar';
+import ProfileInformation from '../../../components/organisms/ProfileInformation';
+import ProfileStream from '../../../components/organisms/ProfileStream';
+import ProfileEvents from '../../../components/organisms/ProfileEvents';
+import ProfileTopics from '../../../components/organisms/ProfileTopics';
+import ProfileGroups from '../../../components/organisms/ProfileGroups';
+import {deviceMinWidth, deviceMaxWidth} from '../../../utils/device';
+import HorizontalLine from '../../../components/atoms/HorizontalLine';
+import RecentActivity from '../../../components/organisms/RecentActivity';
+import {getCookie} from '../../../utils/cookie';
 
 const ProfileContentContainer = styled.div`
   display: flex;
@@ -108,13 +109,20 @@ function UserInformation({name}) {
 UserInformation.getInitialProps = async ctx => {
   // Get name of the user from the id passed in url
   return axios
-    .get(`${API_URL}/jsonapi/user/user/${ctx.query.id}`)
+    .get(
+      `${API_URL}/jsonapi/user/user?filter[drupal_internal__uid][value]=${ctx.query.id}`,
+      {
+        headers: {
+          Authorization: 'Bearer ' + getCookie('token', ctx.req),
+        },
+      },
+    )
     .then(response => {
-      const name = response.data.data.attributes.name;
+      const name = response.data.data[0].attributes.name;
       return {name};
     })
     .catch(err => {
-      throw new Error(`Error occured while fetching user: ${err}`);
+      throw new Error(`Error occured while fetching user`);
     });
 };
 

--- a/app/pages/user/[id]/profile.js
+++ b/app/pages/user/[id]/profile.js
@@ -1,17 +1,17 @@
 import React, {useState, useEffect} from 'react';
-import Layout from '../components/Layout';
-import Card from '../components/organisms/Card';
-import CardHeader from '../components/atoms/CardHeader';
-import CardBody from '../components/atoms/CardBody';
-import Title from '../components/atoms/Title';
-import Button from '../components/atoms/BaseButton';
+import Layout from '../../../components/Layout';
+import Card from '../../../components/organisms/Card';
+import CardHeader from '../../../components/atoms/CardHeader';
+import CardBody from '../../../components/atoms/CardBody';
+import Title from '../../../components/atoms/Title';
+import Button from '../../../components/atoms/BaseButton';
 import styled from 'styled-components';
-import BlockFormField from '../components/molecules/BlockFormField';
-import InputLabel from '../components/atoms/InputLabel';
-import Input from '../components/atoms/Input';
-import TextButton from '../components/atoms/TextButton';
+import BlockFormField from '../../../components/molecules/BlockFormField';
+import InputLabel from '../../../components/atoms/InputLabel';
+import Input from '../../../components/atoms/Input';
+import TextButton from '../../../components/atoms/TextButton';
 import Link from 'next/link';
-import InputDescription from '../components/atoms/InputDescription';
+import InputDescription from '../../../components/atoms/InputDescription';
 
 const Form = styled.form`
   flex-direction: column;

--- a/app/pages/user/[id]/stream.js
+++ b/app/pages/user/[id]/stream.js
@@ -4,19 +4,20 @@ import axios from 'axios';
 import {useRouter} from 'next/router';
 import styled from 'styled-components';
 import React, {useState, useEffect} from 'react';
-import Layout from '../components/Layout';
-import {API_URL} from '../utils/constants';
-import ProfileHero from '../components/atoms/ProfileHero';
-import UserCard from '../components/molecules/UserCard';
-import ProfileNavigationBar from '../components/molecules/ProfileNavigationBar';
-import ProfileInformation from '../components/organisms/ProfileInformation';
-import ProfileStream from '../components/organisms/ProfileStream';
-import ProfileEvents from '../components/organisms/ProfileEvents';
-import ProfileTopics from '../components/organisms/ProfileTopics';
-import ProfileGroups from '../components/organisms/ProfileGroups';
-import RecentActivity from '../components/organisms/RecentActivity';
-import HorizontalLine from '../components/atoms/HorizontalLine';
-import {deviceMinWidth, deviceMaxWidth} from '../utils/device';
+import Layout from '../../../components/Layout';
+import {API_URL} from '../../../utils/constants';
+import ProfileHero from '../../../components/atoms/ProfileHero';
+import UserCard from '../../../components/molecules/UserCard';
+import ProfileNavigationBar from '../../../components/molecules/ProfileNavigationBar';
+import ProfileInformation from '../../../components/organisms/ProfileInformation';
+import ProfileStream from '../../../components/organisms/ProfileStream';
+import ProfileEvents from '../../../components/organisms/ProfileEvents';
+import ProfileTopics from '../../../components/organisms/ProfileTopics';
+import ProfileGroups from '../../../components/organisms/ProfileGroups';
+import RecentActivity from '../../../components/organisms/RecentActivity';
+import HorizontalLine from '../../../components/atoms/HorizontalLine';
+import {deviceMinWidth, deviceMaxWidth} from '../../../utils/device';
+import {getCookie} from '../../../utils/cookie';
 
 const ProfileContentContainer = styled.div`
   display: flex;
@@ -108,13 +109,20 @@ function User({name}) {
 User.getInitialProps = async ctx => {
   // Get name of the user from the id passed in url
   return axios
-    .get(`${API_URL}/jsonapi/user/user/${ctx.query.id}`)
+    .get(
+      `${API_URL}/jsonapi/user/user?filter[drupal_internal__uid][value]=${ctx.query.id}`,
+      {
+        headers: {
+          Authorization: 'Bearer ' + getCookie('token', ctx.req),
+        },
+      },
+    )
     .then(response => {
-      const name = response.data.data.attributes.name;
+      const name = response.data.data[0].attributes.name;
       return {name};
     })
     .catch(err => {
-      throw new Error(`Error occured while fetching user: ${err}`);
+      throw new Error(`Error occured while fetching user`);
     });
 };
 

--- a/app/pages/user/[id]/topics.js
+++ b/app/pages/user/[id]/topics.js
@@ -4,19 +4,20 @@ import axios from 'axios';
 import {useRouter} from 'next/router';
 import styled from 'styled-components';
 import React, {useState} from 'react';
-import Layout from '../components/Layout';
-import {API_URL} from '../utils/constants';
-import ProfileHero from '../components/atoms/ProfileHero';
-import UserCard from '../components/molecules/UserCard';
-import ProfileNavigationBar from '../components/molecules/ProfileNavigationBar';
-import ProfileInformation from '../components/organisms/ProfileInformation';
-import ProfileStream from '../components/organisms/ProfileStream';
-import ProfileEvents from '../components/organisms/ProfileEvents';
-import ProfileTopics from '../components/organisms/ProfileTopics';
-import ProfileGroups from '../components/organisms/ProfileGroups';
-import {deviceMinWidth, deviceMaxWidth} from '../utils/device';
-import HorizontalLine from '../components/atoms/HorizontalLine';
-import RecentActivity from '../components/organisms/RecentActivity';
+import Layout from '../../../components/Layout';
+import {API_URL} from '../../../utils/constants';
+import ProfileHero from '../../../components/atoms/ProfileHero';
+import UserCard from '../../../components/molecules/UserCard';
+import ProfileNavigationBar from '../../../components/molecules/ProfileNavigationBar';
+import ProfileInformation from '../../../components/organisms/ProfileInformation';
+import ProfileStream from '../../../components/organisms/ProfileStream';
+import ProfileEvents from '../../../components/organisms/ProfileEvents';
+import ProfileTopics from '../../../components/organisms/ProfileTopics';
+import ProfileGroups from '../../../components/organisms/ProfileGroups';
+import {deviceMinWidth, deviceMaxWidth} from '../../../utils/device';
+import HorizontalLine from '../../../components/atoms/HorizontalLine';
+import RecentActivity from '../../../components/organisms/RecentActivity';
+import {getCookie} from '../../../utils/cookie';
 
 const ProfileContentContainer = styled.div`
   display: flex;
@@ -68,10 +69,10 @@ const getAvailableTabs = () => ({
   information: ProfileInformation,
 });
 
-function UserGroups({name}) {
+function UserTopics({name}) {
   const router = useRouter();
 
-  const [currentTab, setCurrentTab] = useState('groups');
+  const [currentTab, setCurrentTab] = useState('topics');
   const tabs = getAvailableTabs();
 
   if (typeof tabs[currentTab] === 'undefined') {
@@ -98,28 +99,35 @@ function UserGroups({name}) {
             setCurrentTab={setCurrentTab}
             userId={router.query.id}
           />
-          <ProfileGroups />
+          <ProfileTopics />
         </ProfileRightColumn>
       </ProfileContentContainer>
     </Layout>
   );
 }
 
-UserGroups.getInitialProps = ctx => {
+UserTopics.getInitialProps = async ctx => {
   // Get name of the user from the id passed in url
   return axios
-    .get(`${API_URL}/jsonapi/user/user/${ctx.query.id}`)
+    .get(
+      `${API_URL}/jsonapi/user/user?filter[drupal_internal__uid][value]=${ctx.query.id}`,
+      {
+        headers: {
+          Authorization: 'Bearer ' + getCookie('token', ctx.req),
+        },
+      },
+    )
     .then(response => {
-      const name = response.data.data.attributes.name;
+      const name = response.data.data[0].attributes.name;
       return {name};
     })
     .catch(err => {
-      throw new Error(`Error occured while fetching user: ${err}`);
+      throw new Error(`Error occured while fetching user`);
     });
 };
 
-UserGroups.propTypes = {
+UserTopics.propTypes = {
   name: PropTypes.string,
 };
 
-export default UserGroups;
+export default UserTopics;

--- a/app/pages/user/login.js
+++ b/app/pages/user/login.js
@@ -1,21 +1,21 @@
 import React, {useState, useEffect} from 'react';
 import styled from 'styled-components';
 import Router from 'next/router';
-import Layout from '../components/Layout';
-import Card from '../components/organisms/Card';
-import CardHeader from '../components/atoms/CardHeader';
-import CardBody from '../components/atoms/CardBody';
-import CardFooter from '../components/atoms/CardFooter';
-import Title from '../components/atoms/Title';
-import RaisedButton from '../components/atoms/RaisedButton';
-import SystemMessage from '../components/atoms/SystemMessage';
-import BlockFormField from '../components/molecules/BlockFormField';
-import InputLabel from '../components/atoms/InputLabel';
-import Input from '../components/atoms/Input';
-import InputDescription from '../components/atoms/InputDescription';
-import {withTranslation} from '../i18n';
-import {useUser, useDispatchUser} from '../components/auth/userContext';
-import {loginCall} from '../components/auth/loginCall';
+import Layout from '../../components/Layout';
+import Card from '../../components/organisms/Card';
+import CardHeader from '../../components/atoms/CardHeader';
+import CardBody from '../../components/atoms/CardBody';
+import CardFooter from '../../components/atoms/CardFooter';
+import Title from '../../components/atoms/Title';
+import RaisedButton from '../../components/atoms/RaisedButton';
+import SystemMessage from '../../components/atoms/SystemMessage';
+import BlockFormField from '../../components/molecules/BlockFormField';
+import InputLabel from '../../components/atoms/InputLabel';
+import Input from '../../components/atoms/Input';
+import InputDescription from '../../components/atoms/InputDescription';
+import {withTranslation} from '../../i18n';
+import {useUser, useDispatchUser} from '../../components/auth/userContext';
+import {loginCall} from '../../components/auth/loginCall';
 
 const Wrapper = styled.div`
   margin: auto;
@@ -56,7 +56,7 @@ function Login() {
           type: 'LOGIN',
           payload: res,
         });
-        Router.push('/whoami');
+        Router.push('/');
       })
       .catch(err => {
         setError(true);

--- a/app/server.js
+++ b/app/server.js
@@ -18,18 +18,18 @@ app
     server.use(cookieParser());
     server.use(nextI18NextMiddleware(nextI18next));
 
-    server.get('/login', (req, res) => {
+    server.get('/user/login', (req, res) => {
       if (req.cookies.token) {
         res.redirect('/');
         res.end();
       } else {
-        return app.render(req, res, '/login', req.query);
+        return app.render(req, res, '/user/login', req.query);
       }
     });
 
     server.get('/editprofile', (req, res) => {
       if (!req.cookies.token) {
-        res.redirect('/login');
+        res.redirect('/user/login');
         res.end();
       } else {
         console.log(req);
@@ -39,7 +39,7 @@ app
 
     server.get('/user', (req, res) => {
       if (!req.cookies.token) {
-        res.redirect('/login');
+        res.redirect('/user/login');
         res.end();
       } else {
         return app.render(req, res, '/user', req.query);

--- a/app/server.js
+++ b/app/server.js
@@ -46,6 +46,20 @@ app
       }
     });
 
+    server.get('/user/:id/home', (req, res) => {
+      if (!req.cookies.token) {
+        res.redirect('/user/login');
+        res.end();
+      } else {
+        return app.render(
+          req,
+          res,
+          '/user/' + req.params.id + '/stream',
+          req.query,
+        );
+      }
+    });
+
     server.get('*', (req, res) => {
       return handle(req, res);
     });


### PR DESCRIPTION
## Problem
The profile page routes are all using the urls: (/user?id=:id).
The edit profile page route is using the url: (/editprofile)
The login page route is using the url: (/login)
The register links are pointing towards: (/signup)

## Solution
This pull request refactors all the above to match the Drupal url structure.
Profile page becomes (/user/:id/)
Edit profile becomes (/user/:id/profile)
Login url becomes (/user/login)
Register links now point at (/user/register/)

## Issue tracker
[Ticket](https://getopensocial.atlassian.net/browse/RFE-166?atlOrigin=eyJpIjoiNjM3YjU4YWY0NGZlNGQ1YmE0NmUxZWJjYzU5ZDU5ZjciLCJwIjoiaiJ9)

