### PR TITLE
Extract parser logic from _error.js

### DIFF
--- a/app/pages/_error.js
+++ b/app/pages/_error.js
@@ -14,7 +14,9 @@ const ErrorMessage = styled.p`
 `;
 
 function Error({statusCode, htmlHead, htmlBody, svgs, scripts}) {
-  // if the page is found on drupal then we render it
+  // in the case of a 404 error a request is made to the server/API
+  // to check if the page exists there, if true we are returned
+  // a 200 status code and a page to render
   if (statusCode === 200) {
     return renderPage(htmlHead, htmlBody, svgs, scripts);
     // if the page does not exist at all display an error message

--- a/app/pages/_error.js
+++ b/app/pages/_error.js
@@ -2,36 +2,24 @@ import React from 'react';
 import axios from 'axios';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import Layout from '../components/Layout';
-import Head from 'next/head';
 import {withTranslation} from '../i18n';
 import {API_URL} from '../utils/constants';
 import {getCookie} from '../utils/cookie';
-import ReactHtmlParser from 'react-html-parser';
-import DOMParser from '../utils/domparser';
+import Layout from '../components/Layout';
+import {renderPage, parseResponse} from '../utils/htmlResponseParser';
 
 // A custom error page displaying the error status code to the user and whether the error occured server side or client side
 const ErrorMessage = styled.p`
   padding: ${props => props.theme.layout.padding};
 `;
 
-const DrupalContent = styled.div`
-  margin: -50px 0 -100px 0;
-`;
-
-function createMarkup(html) {
-  return {__html: html};
-}
-
 function Error({statusCode, htmlHead, htmlBody, svgs}) {
+  // if the page is found on drupal then we render it
   if (statusCode === 200) {
     return (
-      <Layout>
-        <Head>{ReactHtmlParser(htmlHead)}</Head>
-        <DrupalContent dangerouslySetInnerHTML={createMarkup(htmlBody)} />
-        <div dangerouslySetInnerHTML={createMarkup(svgs)} />
-      </Layout>
+      <React.Fragment>{renderPage(htmlHead, htmlBody, svgs)}</React.Fragment>
     );
+    // if the page does not exist at all display an error message
   } else {
     return (
       <Layout title="Error | Open Social">
@@ -55,6 +43,7 @@ Error.getInitialProps = async ctx => {
 
   const namespacesRequired = {namespacesRequired: ['common', 'header']};
 
+  // if page does not exist on the React application then perform a GET request to the Drupal site to check if it exists there
   if (statusCode === 404) {
     return axios
       .get(API_URL + requestedUrl, {
@@ -63,74 +52,16 @@ Error.getInitialProps = async ctx => {
         },
       })
       .then(response => {
-        // create document object model
-        const dom = new DOMParser(response.data);
-        const doc = dom.window.document;
-
-        // remove search element
-        var searchElement = doc.getElementsByClassName('region--content-top');
-        if (searchElement[0]) {
-          searchElement[0].parentNode.removeChild(searchElement[0]);
-        }
-
-        // set all links (incl. stylesheets) href to our drupal domain
-        var styleSheets = doc.getElementsByTagName('link');
-        for (var i = 0; i < styleSheets.length; i++) {
-          if (!styleSheets[i].href.includes(API_URL)) {
-            let oldHref = styleSheets[i].href;
-            let newHref = API_URL + oldHref;
-            styleSheets[i].href = newHref;
-          }
-        }
-
-        // set all img src to our drupal domain
-        var imgs = doc.getElementsByTagName('img');
-        for (var i = 0; i < imgs.length; i++) {
-          if (!imgs[i].src.includes(API_URL)) {
-            let oldSrc = imgs[i].src;
-            let newSrc = API_URL + oldSrc;
-            imgs[i].src = newSrc;
-          }
-        }
-
-        // remove the drupal domain href from a tags (drupaldomain.com/user -> /user)
-        var a = doc.getElementsByTagName('a');
-        for (var i = 0; i < a.length; i++) {
-          if (a[i].href.includes(API_URL)) {
-            let oldHref = a[i].href;
-            let newHref = oldHref.replace(API_URL, '');
-            a[i].href = newHref;
-          }
-        }
-
-        // set all script src to our drupal domain
-        // var scripts = doc.getElementsByTagName('script');
-        // for (var i = 0; i < scripts.length; i++) {
-        //   if (!scripts[i].src.includes(API_URL)) {
-        //     let oldSrc = scripts[i].src;
-        //     let newSrc = API_URL + oldSrc;
-        //     scripts[i].src = newSrc;
-        //   }
-        // }
-
-        // set head, body
-        const htmlHead = doc.head.innerHTML;
-        const htmlBody = doc.getElementById('content').outerHTML;
-
-        // set svgs
-        const svgArray = doc.getElementsByTagName('svg');
-        const svgs = svgArray[svgArray.length - 1].outerHTML;
-
+        const {head, body, svgs} = parseResponse(response);
         return {
-          htmlBody: htmlBody,
-          htmlHead: htmlHead,
+          htmlBody: body,
+          htmlHead: head,
           svgs: svgs,
           statusCode: 200,
           namespacesRequired,
         };
       })
       .catch(err => {
-        console.log(err);
         return {statusCode: 404, namespacesRequired};
       });
   } else {

--- a/app/pages/_error.js
+++ b/app/pages/_error.js
@@ -16,11 +16,7 @@ const ErrorMessage = styled.p`
 function Error({statusCode, htmlHead, htmlBody, svgs, scripts}) {
   // if the page is found on drupal then we render it
   if (statusCode === 200) {
-    return (
-      <React.Fragment>
-        {renderPage(htmlHead, htmlBody, svgs, scripts)}
-      </React.Fragment>
-    );
+    return renderPage(htmlHead, htmlBody, svgs, scripts);
     // if the page does not exist at all display an error message
   } else {
     return (

--- a/app/utils/htmlResponseParser.js
+++ b/app/utils/htmlResponseParser.js
@@ -1,0 +1,93 @@
+import Head from 'next/head';
+import ReactHtmlParser from 'react-html-parser';
+import {API_URL} from './constants';
+import {createHtmlMarkup} from './markup';
+import DOMParser from '../utils/domparser';
+import Layout from '../components/Layout';
+import styled from 'styled-components';
+
+const DrupalContent = styled.div`
+  margin: -50px 0 -100px 0;
+`;
+
+export function renderPage(head, body, svgs) {
+  return (
+    <Layout>
+      <Head>{ReactHtmlParser(head)}</Head>
+      <DrupalContent dangerouslySetInnerHTML={createHtmlMarkup(body)} />
+      <div dangerouslySetInnerHTML={createHtmlMarkup(svgs)} />
+    </Layout>
+  );
+}
+
+// This function parses the html response from Drupal
+// It sets all the src's and href's to that of our React application
+// And it returns
+// - head = head tags, including scripts and meta tags
+// - body = the page body in html format
+// - svgs = the svg icons that searchResults uses
+export function parseResponse(response) {
+  // create document object model
+  const dom = new DOMParser(response.data);
+  const doc = dom.window.document;
+
+  // remove search element
+  var searchElement = doc.getElementsByClassName('region--content-top');
+  if (searchElement[0]) {
+    searchElement[0].parentNode.removeChild(searchElement[0]);
+  }
+
+  // set all links (incl. stylesheets) href to our drupal domain
+  var styleSheets = doc.getElementsByTagName('link');
+  for (var i = 0; i < styleSheets.length; i++) {
+    if (!styleSheets[i].href.includes(API_URL)) {
+      let oldHref = styleSheets[i].href;
+      let newHref = API_URL + oldHref;
+      styleSheets[i].href = newHref;
+    }
+  }
+
+  // set all img src to our drupal domain
+  var imgs = doc.getElementsByTagName('img');
+  for (var i = 0; i < imgs.length; i++) {
+    if (!imgs[i].src.includes(API_URL)) {
+      let oldSrc = imgs[i].src;
+      let newSrc = API_URL + oldSrc;
+      imgs[i].src = newSrc;
+    }
+  }
+
+  // remove the drupal domain href from a tags (drupaldomain.com/user -> /user)
+  var a = doc.getElementsByTagName('a');
+  for (var i = 0; i < a.length; i++) {
+    if (a[i].href.includes(API_URL)) {
+      let oldHref = a[i].href;
+      let newHref = oldHref.replace(API_URL, '');
+      a[i].href = newHref;
+    }
+  }
+
+  // set all script src to our drupal domain
+  // var scripts = doc.getElementsByTagName('script');
+  // for (var i = 0; i < scripts.length; i++) {
+  //   if (!scripts[i].src.includes(API_URL)) {
+  //     let oldSrc = scripts[i].src;
+  //     let newSrc = API_URL + oldSrc;
+  //     scripts[i].src = newSrc;
+  //   }
+  // }
+
+  // set head, body
+  const htmlHead = doc.head.innerHTML;
+  const htmlBody = doc.getElementById('content').outerHTML;
+
+  // set svgs
+  const svgArray = doc.getElementsByTagName('svg');
+  const svgs = svgArray[svgArray.length - 1].outerHTML;
+
+  return {
+    body: htmlBody,
+    head: htmlHead,
+    svgs: svgs,
+  };
+}

--- a/app/utils/htmlResponseParser.js
+++ b/app/utils/htmlResponseParser.js
@@ -10,6 +10,8 @@ const DrupalContent = styled.div`
   margin: -50px 0 -100px 0;
 `;
 
+// This is a render function which is used for the rendering of Drupal pages
+// This is not a generic render function
 export function renderPage(head, body, svgs, scripts) {
   return (
     <Layout>

--- a/app/utils/markup.js
+++ b/app/utils/markup.js
@@ -1,0 +1,3 @@
+export function createHtmlMarkup(html) {
+  return {__html: html};
+}


### PR DESCRIPTION
## Problem
The logic for parsing the html response from Drupal is unnecessarily inside the _error.js.

## Solution
Extract the logic to a separate file to improve code readability and maintenance.

## Issue tracker
[Jira Ticket](https://getopensocial.atlassian.net/browse/RFE-187?atlOrigin=eyJpIjoiNzlmMWMwYzhjZWNmNDUxZDliODFjNzllYTJiMjkyMzIiLCJwIjoiaiJ9)
