### PR TITLE
Parse scripts from Drupal response

### DIFF
--- a/app/pages/_error.js
+++ b/app/pages/_error.js
@@ -13,11 +13,13 @@ const ErrorMessage = styled.p`
   padding: ${props => props.theme.layout.padding};
 `;
 
-function Error({statusCode, htmlHead, htmlBody, svgs}) {
+function Error({statusCode, htmlHead, htmlBody, svgs, scripts}) {
   // if the page is found on drupal then we render it
   if (statusCode === 200) {
     return (
-      <React.Fragment>{renderPage(htmlHead, htmlBody, svgs)}</React.Fragment>
+      <React.Fragment>
+        {renderPage(htmlHead, htmlBody, svgs, scripts)}
+      </React.Fragment>
     );
     // if the page does not exist at all display an error message
   } else {
@@ -52,11 +54,12 @@ Error.getInitialProps = async ctx => {
         },
       })
       .then(response => {
-        const {head, body, svgs} = parseResponse(response);
+        const {head, body, svgs, scripts} = parseResponse(response);
         return {
           htmlBody: body,
           htmlHead: head,
-          svgs: svgs,
+          svgs,
+          scripts,
           statusCode: 200,
           namespacesRequired,
         };

--- a/app/utils/htmlResponseParser.js
+++ b/app/utils/htmlResponseParser.js
@@ -10,12 +10,13 @@ const DrupalContent = styled.div`
   margin: -50px 0 -100px 0;
 `;
 
-export function renderPage(head, body, svgs) {
+export function renderPage(head, body, svgs, scripts) {
   return (
     <Layout>
       <Head>{ReactHtmlParser(head)}</Head>
       <DrupalContent dangerouslySetInnerHTML={createHtmlMarkup(body)} />
       <div dangerouslySetInnerHTML={createHtmlMarkup(svgs)} />
+      <div dangerouslySetInnerHTML={createHtmlMarkup(scripts)} />
     </Layout>
   );
 }
@@ -68,14 +69,16 @@ export function parseResponse(response) {
   }
 
   // set all script src to our drupal domain
-  // var scripts = doc.getElementsByTagName('script');
-  // for (var i = 0; i < scripts.length; i++) {
-  //   if (!scripts[i].src.includes(API_URL)) {
-  //     let oldSrc = scripts[i].src;
-  //     let newSrc = API_URL + oldSrc;
-  //     scripts[i].src = newSrc;
-  //   }
-  // }
+  var htmlScripts = '';
+  var scripts = doc.getElementsByTagName('script');
+  for (var i = 0; i < scripts.length; i++) {
+    if (!scripts[i].src.includes(API_URL)) {
+      let oldSrc = scripts[i].src;
+      let newSrc = API_URL + oldSrc;
+      scripts[i].src = newSrc;
+    }
+    htmlScripts += scripts[i].outerHTML;
+  }
 
   // set head, body
   const htmlHead = doc.head.innerHTML;
@@ -89,5 +92,6 @@ export function parseResponse(response) {
     body: htmlBody,
     head: htmlHead,
     svgs: svgs,
+    scripts: htmlScripts,
   };
 }


### PR DESCRIPTION
## Problem
Currently scripts are not parsed from the Drupal response. This causes issues with certain functionality/interactive elements such as dropdown menus.

## Solution
Parse the scripts from the Drupal response and append them to the page body.

## Issue tracker
[Jira Ticket](https://getopensocial.atlassian.net/browse/RFE-181?atlOrigin=eyJpIjoiYTZjNGNlOGEwMDRjNDhhYmExZWVkZTNiYzAyMDgzOTEiLCJwIjoiaiJ9)

