### PR TITLE
Fix CORS error when importing font + add font caching

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -14,8 +14,3 @@
 "https://api.{default}/":
   type: upstream
   upstream: "api:http"
-  cache:
-    enabled: true
-    default_ttl: 0
-    cookies: ["*"]
-    headers: ["Accept", "Accept-Language"]

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -14,3 +14,8 @@
 "https://api.{default}/":
   type: upstream
   upstream: "api:http"
+  cache:
+    enabled: true
+    default_ttl: 0
+    cookies: ["*"]
+    headers: ["Accept", "Accept-Language"]

--- a/api/.platform.app.yaml
+++ b/api/.platform.app.yaml
@@ -74,6 +74,12 @@ web:
         "^/sites/default/files/(css|jss)":
           expires: 2w
 
+    "/profiles/contrib/social/themes/"
+      # Allow access to all files in the themes directory
+      allow: true
+      headers:
+        Access-Control-Allow-Origin: "*"
+
 # The size of the persistent disk of the application (in MB).
 disk: 2048
 

--- a/api/.platform.app.yaml
+++ b/api/.platform.app.yaml
@@ -74,7 +74,7 @@ web:
         "^/sites/default/files/(css|jss)":
           expires: 2w
 
-    "/profiles/contrib/social/themes/"
+    "/profiles/contrib/social/themes/":
       # Allow access to all files in the themes directory
       allow: true
       headers:

--- a/api/.platform.app.yaml
+++ b/api/.platform.app.yaml
@@ -77,6 +77,11 @@ web:
     "/profiles/contrib/social/themes/":
       # Allow access to all files in the themes directory
       allow: true
+      # How long to allow static assets from this location to be cached.
+      # (Can be a time or -1 for no caching. Times can be suffixed with
+      # "ms" (milliseconds), "s" (seconds), "m" (minutes), "h" (hours),
+      # "d" (days), "w" (weeks), "M" (months, 30d) or "y" (years, 365d).)
+      expires: 1d
       headers:
         Access-Control-Allow-Origin: "*"
 


### PR DESCRIPTION
## Problem
When a font is imported from the Drupal stylesheet the React application throws a cors error. Also because font's are not cached this results in a FOIT (Flash of invisible text). 

## Solution
Enable cors in the font directory and add font caching through .platform.app.yaml

## Issue tracker
[Jira Issue](https://getopensocial.atlassian.net/browse/RFE-183?atlOrigin=eyJpIjoiNWZmZTE2ZWY1ZDI2NDYyOThiNjgyNGMxOTMxMmExMGEiLCJwIjoiaiJ9)

